### PR TITLE
fix(crontab): Add missing WIFF_ROOT env var in crontab (closes #5192)

### DIFF
--- a/include/class/Class.Crontab.php
+++ b/include/class/Class.Crontab.php
@@ -115,7 +115,7 @@ class Crontab
             return FALSE;
         }
         
-        $crontab = "# BEGIN:CONTROL_CRONTAB:" . $this->wiff_root . ":" . $file . "\n" . $crontab . "\n" . "# END:CONTROL_CRONTAB:" . $this->wiff_root . ":" . $file . "\n";
+        $crontab = "# BEGIN:CONTROL_CRONTAB:" . $this->wiff_root . ":" . $file . "\n" . "WIFF_ROOT=" . $this->wiff_root . "\n" . $crontab . "\n" . "# END:CONTROL_CRONTAB:" . $this->wiff_root . ":" . $file . "\n";
         
         $activeCrontab = $this->load();
         if ($activeCrontab === FALSE) {

--- a/migr/1.5.0-0
+++ b/migr/1.5.0-0
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-$WIFF_ROOT = dirname(__FILE__).DIRECTORY_SEPARATOR.'..';
+$WIFF_ROOT = realpath(dirname(__FILE__).DIRECTORY_SEPARATOR.'..');
 set_include_path(get_include_path().PATH_SEPARATOR.$WIFF_ROOT.DIRECTORY_SEPARATOR.'include');
 putenv('WIFF_ROOT='.$WIFF_ROOT);
 
@@ -85,6 +85,16 @@ if (file_exists($oldLog)) {
     }
   }
   unlink($oldLog);
+}
+
+/*
+ * Update crontab
+ */
+$crontab = new Crontab();
+if ($crontab->registerFile("control.cron") === false) {
+    $err = $crontab->getErrors();
+    error_log(sprintf("Error re-registering crontab 'control.cron': %s", $err));
+    exit(1);
 }
 
 exit(0);


### PR DESCRIPTION
Also:
- Re-register crontab in migr/1.5.0-0
- To manually re-register crontab run:

    ./wiff crontab cmd register file control.cron